### PR TITLE
Create objective-c-xcode.yml

### DIFF
--- a/.github/workflows/objective-c-xcode.yml
+++ b/.github/workflows/objective-c-xcode.yml
@@ -1,0 +1,40 @@
+name: Xcode Build
+
+on:
+  push:
+    branches: [ "main" ] # or "master" if your main branch is named master
+  pull_request:
+    branches: [ "main" ] # or "master"
+
+jobs:
+  build:
+    runs-on: macos-latest # Use the latest macOS runner
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4 # Checks out your repository under $GITHUB_WORKSPACE
+
+      - name: Select Xcode version
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: 'latest' # or specify a version like '15.0' or '14.3.1'
+
+      - name: No extra dependencies - Proceed with build
+        run: echo "No extra dependencies to install. Proceeding with Xcode build."
+
+      - name: Build Xcode project
+        run: xcodebuild -project CapsLockSwitcher.xcodeproj -scheme CapsLockSwitcher -destination 'generic/platform=macOS' -configuration Release CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+
+      - name: Create App Archive (ZIP)
+        run: |
+          mkdir build
+          cp -R "build/Release/CapsLockSwitcher.app" build/
+          cd build
+          zip -r CapsLockSwitcher.app.zip CapsLockSwitcher.app
+          echo "App archive created: CapsLockSwitcher.app.zip"
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: CapsLockSwitcher-app
+          path: build/CapsLockSwitcher.app.zip


### PR DESCRIPTION
feat: Add GitHub Actions workflow for Xcode builds

This PR introduces a GitHub Actions workflow (`.github/workflows/xcode-build.yml`) to automatically build the Xcode project on push and pull requests to the `main` branch.

This workflow generates a ZIP archive of the built `.app` file and uploads it as an artifact.

This is a basic build workflow without code signing.